### PR TITLE
Removing extra greater than symbol '>'

### DIFF
--- a/app/code/Magecomp/Extrafee/etc/module.xml
+++ b/app/code/Magecomp/Extrafee/etc/module.xml
@@ -5,7 +5,7 @@
             <module name="Magento_Backend"/>
              <module name="Magento_Sales"/>
             <module name="Magento_Quote"/>
-            <module name="Magento_Checkout"/>>
+            <module name="Magento_Checkout"/>               
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
Removing extra greater than symbol '>' to avoid syntax error.